### PR TITLE
Refactor tests; fix GenerateRandBlocks and OCSP output

### DIFF
--- a/combinedtree_test.go
+++ b/combinedtree_test.go
@@ -6,79 +6,16 @@ import (
 )
 
 /*
-Test suite co-written using AI (Gemini 3 Pro)
+Some tests co-written using Claude 4.6 Sonnet
 */
-func TestNewCombinedTree(t *testing.T) {
-	blocks, err := GenerateRandBlocks(10)
-	if err != nil {
-		t.Fatalf("Failed to generate random blocks: %v", err)
-	}
-
-	tree, err := NewCombinedTree(blocks)
-
-	if err != nil {
-		t.Fatalf("NewCombinedTree() returned an unexpected error: %v", err)
-	}
-
-	if tree == nil {
-		t.Fatal("NewCombinedTree() returned a nil tree")
-	}
-
-	if tree.issuedMT == nil {
-		t.Error("Expected issuedMT to be initialized, but got nil")
-	}
-
-	if tree.revSMT == nil {
-		t.Error("Expected revSMT to be initialized, but got nil")
-	}
-}
-func TestAddRevocationToTree(t *testing.T) {
-	blocks, err := GenerateRandBlocks(10)
-	if err != nil {
-		t.Fatalf("Failed to generate random blocks: %v", err)
-	}
-
-	tree, err := NewCombinedTree(blocks)
-	if err != nil {
-		t.Fatalf("Failed to set up test tree: %v", err)
-	}
-
-	testValue := []byte("revoked-credential-id-12345")
-
-	newRoot, err := tree.addRevocationToTree(testValue)
-	if err != nil {
-		t.Fatalf("addRevocationToTree() returned an error: %v", err)
-	}
-
-	if len(newRoot) == 0 {
-		t.Error("Expected a valid new root hash, but got an empty byte slice")
-	}
-
-	retrievedValue, err := tree.revSMT.Get(testValue)
-	if err != nil {
-		t.Fatalf("Failed to retrieve value from revSMT: %v", err)
-	}
-
-	if !bytes.Equal(retrievedValue, testValue) {
-		t.Errorf("Expected retrieved value from SMT to be %s, got %s", testValue, retrievedValue)
-	}
-
-	hasValue, err := tree.revSMT.Has(testValue)
-	if err != nil {
-		t.Fatalf("Failed to check if tree has value: %v", err)
-	}
-	if !hasValue {
-		t.Error("Tree.Has() reported false for a value that was just added")
-	}
-}
 func TestAddBulkRevocationToTree(t *testing.T) {
 	blocks, err := GenerateRandBlocks(10)
 	if err != nil {
-		t.Fatalf("Failed to generate random blocks: %v", err)
+		t.Fatalf("failed to generate random blocks: %v", err)
 	}
 	tree, err := NewCombinedTree(blocks)
 	if err != nil {
-		t.Fatalf("Failed to set up test tree: %v", err)
+		t.Fatalf("failed to set up test tree: %v", err)
 	}
 
 	bulkData := [][]byte{
@@ -90,228 +27,83 @@ func TestAddBulkRevocationToTree(t *testing.T) {
 
 	newRoot, err := tree.addBulkRevocationToTree(bulkData)
 	if err != nil {
-		t.Fatalf("addBulkRevocationToTree() returned an unexpected error: %v", err)
+		t.Fatalf("addBulkRevocationToTree() unexpected error: %v", err)
 	}
-
 	if len(newRoot) == 0 {
-		t.Error("Expected a valid new root hash, but got an empty byte slice")
+		t.Fatal("expected non-empty root hash")
 	}
 
-	for _, testValue := range bulkData {
-		hasValue, err := tree.revSMT.Has(testValue)
-		if err != nil {
-			t.Errorf("Failed to check if tree has value %s: %v", testValue, err)
-		}
-		if !hasValue {
-			t.Errorf("Tree does not contain expected value: %s", testValue)
-		}
-		retrievedValue, err := tree.revSMT.Get(testValue)
-		if err != nil {
-			t.Errorf("Failed to retrieve value %s: %v", testValue, err)
-		}
-		if !bytes.Equal(retrievedValue, testValue) {
-			t.Errorf("Expected retrieved value to be %s, got %s", testValue, retrievedValue)
-		}
-	}
-}
-func TestGetMembershipProof(t *testing.T) {
-	blocks, err := GenerateRandBlocks(10)
-	if err != nil {
-		t.Fatalf("Failed to generate random blocks: %v", err)
-	}
-	tree, err := NewCombinedTree(blocks)
-	if err != nil {
-		t.Fatalf("Failed to set up test tree: %v", err)
-	}
+	for _, val := range bulkData {
+		val := val
+		t.Run(string(val), func(t *testing.T) {
+			has, err := tree.revSMT.Has(val)
+			if err != nil {
+				t.Fatalf("Has(%s): %v", val, err)
+			}
+			if !has {
+				t.Errorf("tree missing expected value: %s", val)
+			}
 
-	testValue := []byte("revoked-credential-proof-test")
-
-	_, err = tree.newMembershipProofRevoked(testValue)
-	if err != nil {
-		t.Fatalf("newMembershipProofRevoked() returned an error for empty tree: %v", err)
-	}
-
-	_, err = tree.addRevocationToTree(testValue)
-	if err != nil {
-		t.Fatalf("Failed to add revocation: %v", err)
-	}
-
-	_, err = tree.newMembershipProofRevoked(testValue)
-	if err != nil {
-		t.Fatalf("newMembershipProofRevoked() returned an error: %v", err)
-	}
-}
-
-func TestValidateSparseMTMembershipProof(t *testing.T) {
-	blocks, err := GenerateRandBlocks(10)
-	if err != nil {
-		t.Fatalf("Failed to generate random blocks: %v", err)
-	}
-	tree, err := NewCombinedTree(blocks)
-	if err != nil {
-		t.Fatalf("Failed to set up test tree: %v", err)
-	}
-
-	testValue := []byte("revoked-credential-valid-proof")
-	wrongValue := []byte("some-other-credential")
-
-	_, err = tree.addRevocationToTree(testValue)
-	if err != nil {
-		t.Fatalf("Failed to add revocation: %v", err)
-	}
-
-	proof, err := tree.newMembershipProofRevoked(testValue)
-	if err != nil {
-		t.Fatalf("Failed to get membership proof: %v", err)
-	}
-
-	isValid, err := tree.validateSparseMTMembershipProof(proof, testValue)
-	if err != nil {
-		t.Fatalf("validateSparseMTMembershipProof() returned an error: %v", err)
-	}
-	if !isValid {
-		t.Error("Expected membership proof to be valid, but got false")
-	}
-
-	isWrongValid, err := tree.validateSparseMTMembershipProof(proof, wrongValue)
-	if err != nil {
-		t.Fatalf("validateSparseMTMembershipProof() returned an error on wrong value: %v", err)
-	}
-	if isWrongValid {
-		t.Error("Expected membership proof to be invalid for a wrong value, but got true")
-	}
-}
-
-func TestValidateSparseMTNonMembershipProof(t *testing.T) {
-	blocks, err := GenerateRandBlocks(10)
-	if err != nil {
-		t.Fatalf("Failed to generate random blocks: %v", err)
-	}
-	tree, err := NewCombinedTree(blocks)
-	if err != nil {
-		t.Fatalf("Failed to set up test tree: %v", err)
-	}
-
-	dummyValue := []byte("dummy-revoked-credential")
-	_, err = tree.addRevocationToTree(dummyValue)
-	if err != nil {
-		t.Fatalf("Failed to add dummy revocation: %v", err)
-	}
-
-	nonExistentValue := []byte("valid-credential-not-revoked")
-
-	proof, err := tree.newMembershipProofRevoked(nonExistentValue)
-	if err != nil {
-		t.Fatalf("Failed to get proof for non-existent value: %v", err)
-	}
-
-	isValidNonMembership, err := tree.validateSparseMTNonMembershipProof(proof, nonExistentValue)
-	if err != nil {
-		t.Fatalf("validateSparseMTNonMembershipProof() returned an error: %v", err)
-	}
-	if !isValidNonMembership {
-		t.Error("Expected non-membership proof to be valid, but got false")
-	}
-
-	isValidMembership, err := tree.validateSparseMTMembershipProof(proof, nonExistentValue)
-	if err != nil {
-		t.Fatalf("validateSparseMTMembershipProof() returned an error during negative check: %v", err)
-	}
-	if isValidMembership {
-		t.Error("Expected membership proof to be invalid for a non-existent value, but got true")
-	}
-}
-func TestAddIssuanceToTree(t *testing.T) {
-	blocks, err := GenerateRandBlocks(10)
-	if err != nil {
-		t.Fatalf("Failed to generate random blocks: %v", err)
-	}
-	tree, err := NewCombinedTree(blocks)
-	if err != nil {
-		t.Fatalf("Failed to set up test tree: %v", err)
-	}
-	tree.addIssuanceToTree()
-}
-func TestUpdateGlobalRoot(t *testing.T) {
-	blocks, err := GenerateRandBlocks(10)
-	if err != nil {
-		t.Fatalf("Failed to generate random blocks: %v", err)
-	}
-	tree, err := NewCombinedTree(blocks)
-	if err != nil {
-		t.Fatalf("Failed to set up test tree: %v", err)
-	}
-
-	if tree.root != nil {
-		t.Error("Expected root to be nil on a fresh tree")
-	}
-
-	_, err = tree.addRevocationToTree([]byte("credential-001"))
-	if err != nil {
-		t.Fatalf("addRevocationToTree() failed: %v", err)
-	}
-	if len(tree.root) == 0 {
-		t.Error("Expected root to be set after mutation, got empty")
-	}
-
-	rootAfterFirst := make([]byte, len(tree.root))
-	copy(rootAfterFirst, tree.root)
-
-	_, err = tree.addRevocationToTree([]byte("credential-002"))
-	if err != nil {
-		t.Fatalf("addRevocationToTree() failed: %v", err)
-	}
-	if bytes.Equal(rootAfterFirst, tree.root) {
-		t.Error("Expected root to change after second mutation, but it stayed the same")
-	}
-	/*
-		Not possible with current NewCombinedTree since it's currently filled with random blocks
-
-		tree2, err := NewCombinedTree()
-		if err != nil {
-			t.Fatalf("Failed to set up second tree: %v", err)
-		}
-		_, err = tree2.addBulkRevocationToTree([][]byte{
-			[]byte("credential-001"),
-			[]byte("credential-002"),
+			got, err := tree.revSMT.Get(val)
+			if err != nil {
+				t.Fatalf("Get(%s): %v", val, err)
+			}
+			if !bytes.Equal(got, val) {
+				t.Errorf("Get(%s) = %s, want %s", val, got, val)
+			}
 		})
-		if err != nil {
-			t.Fatalf("addBulkRevocationToTree() failed: %v", err)
-		}
-		if !bytes.Equal(tree.root, tree2.root) {
-			t.Error("Expected identical trees to produce identical roots")
-		}
-	*/
+	}
+
 }
-
-/*
- TODO: reimplement
-func TestNewMerkle_SortsLeaves(t *testing.T) {
-	var blocks [][]byte
-
-
-	blocks = append(blocks, []byte{200, 200, 200})
-	blocks = append(blocks, []byte{10, 10, 10})
-	blocks = append(blocks, []byte{150, 150, 150})
-	blocks = append(blocks, []byte{50, 50, 50})
-	blocks = append(blocks, []byte{100, 100, 100})
-
-
-	tree, err := NewMerkle(blocks)
+func TestValidateSparseMTProofs(t *testing.T) {
+	blocks, err := GenerateRandBlocks(10)
 	if err != nil {
-		t.Fatalf("NewMerkle() returned an unexpected error: %v", err)
+		t.Fatalf("failed to generate random blocks: %v", err)
 	}
-	if tree == nil {
-		t.Fatal("NewMerkle() returned a nil tree")
+	tree, err := NewCombinedTree(blocks)
+	if err != nil {
+		t.Fatalf("failed to set up test tree: %v", err)
 	}
 
-	for i := 0; i < len(blocks)-1; i++ {
-		dataI, _ := blocks[i].Serialize()
-		dataJ, _ := blocks[i+1].Serialize()
+	revoked := []byte("revoked-credential")
+	notRevoked := []byte("valid-credential-not-revoked")
 
-		if bytes.Compare(dataI, dataJ) > 0 {
-			t.Errorf("Blocks are not sorted correctly!\nIndex %d: %v\nIndex %d: %v",
-				i, dataI, i+1, dataJ)
-		}
+	if _, err := tree.addRevocationToTree(revoked); err != nil {
+		t.Fatalf("addRevocationToTree: %v", err)
 	}
-*/
+
+	tests := []struct {
+		name          string
+		value         []byte
+		wantMember    bool
+		wantNonMember bool
+	}{
+		{"revoked credential", revoked, true, false},
+		{"non-revoked credential", notRevoked, false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			proof, err := tree.newMembershipProofRevoked(tc.value)
+			if err != nil {
+				t.Fatalf("newMembershipProofRevoked: %v", err)
+			}
+
+			isMember, err := tree.validateSparseMTMembershipProof(proof, tc.value)
+			if err != nil {
+				t.Fatalf("validateSparseMTMembershipProof: %v", err)
+			}
+			if isMember != tc.wantMember {
+				t.Errorf("membership = %v, want %v", isMember, tc.wantMember)
+			}
+
+			isNonMember, err := tree.validateSparseMTNonMembershipProof(proof, tc.value)
+			if err != nil {
+				t.Fatalf("validateSparseMTNonMembershipProof: %v", err)
+			}
+			if isNonMember != tc.wantNonMember {
+				t.Errorf("non-membership = %v, want %v", isNonMember, tc.wantNonMember)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -53,6 +53,10 @@ func main() {
 
 	res, err := NewOCSPResponse(cList[4], []byte{}, tree)
 	// Should be of status "GOOD"
-	fmt.Println(res)
-	// Is of status "Unknown", why?
+	if err != nil {
+		panic(err)
+	}
+	// Response Code should be "Good"
+	fmt.Println("Response Code", res.status)
+	// Is of status "Good" ** fixed the issue**
 }

--- a/merkle.go
+++ b/merkle.go
@@ -20,11 +20,11 @@ func (t *certHash) Serialize() ([]byte, error) {
 // generate dummy data blocks
 func GenerateRandBlocks(size int) ([][]byte, error) {
 	var blocks [][]byte
-	pKey, err := NewKeyPair(2048)
-	if err != nil {
-		return nil, err
-	}
 	for i := 0; i < size; i++ {
+		pKey, err := NewKeyPair(2048)
+		if err != nil {
+			return nil, err
+		}
 		certObj, err := NewRandomCertificate(pKey, false)
 
 		if err != nil {

--- a/ocsp_merkle_test.go
+++ b/ocsp_merkle_test.go
@@ -4,22 +4,152 @@ import (
 	"testing"
 )
 
+/*
+Some tests co-written using Claude 4.6 Sonnet
+*/
 func TestNewResponse(t *testing.T) {
-}
-func TestFindTreeTMP(t *testing.T) {
-	d := [][]byte{
-		[]byte("revoked-id-001"),
-		[]byte("revoked-id-002"),
-		[]byte("revoked-id-003"),
-		[]byte("revoked-id-004"),
+	certs, err := GenerateRandBlocks(10)
+	if err != nil {
+		t.Fatalf("Failed to generate certs: %v", err)
 	}
-	tree, _ := NewCombinedTree(d)
 
-	isInTree, _ := tree.smtHas(d[0])
-	if !isInTree {
-		t.Error("Expected data to be in tree")
+	tree, err := NewCombinedTree(certs)
+	if err != nil {
+		t.Fatalf("Failed to create combined tree: %v", err)
 	}
+
+	t.Run("returns response for issued cert", func(t *testing.T) {
+		resp, err := NewOCSPResponse(certs[0], nil, tree)
+		if err != nil {
+			t.Fatalf("NewOCSPResponse() returned error: %v", err)
+		}
+		if resp == nil {
+			t.Fatal("Expected non-nil response")
+		}
+		if resp.proof == nil {
+			t.Error("Expected proof to be set in response")
+		}
+		if resp.timestamp.IsZero() {
+			t.Error("Expected timestamp to be set")
+		}
+	})
+
+	t.Run("response status is Good for issued non-revoked cert", func(t *testing.T) {
+		resp, err := NewOCSPResponse(certs[1], nil, tree)
+		if err != nil {
+			t.Fatalf("NewOCSPResponse() returned error: %v", err)
+		}
+		if resp.status != Good {
+			t.Errorf("Expected status Good (%d), got %d", Good, resp.status)
+		}
+	})
+
+	t.Run("response status is Revoked for revoked cert", func(t *testing.T) {
+		_, err := tree.addRevocationToTree(certs[2])
+		if err != nil {
+			t.Fatalf("Failed to revoke cert: %v", err)
+		}
+		resp, err := NewOCSPResponse(certs[2], nil, tree)
+		if err != nil {
+			t.Fatalf("NewOCSPResponse() returned error: %v", err)
+		}
+		if resp.status != Revoked {
+			t.Errorf("Expected status Revoked (%d), got %d", Revoked, resp.status)
+		}
+	})
+
+	t.Run("response status is Unknown for cert not in tree", func(t *testing.T) {
+		unknownCert := []byte("cert-never-issued")
+		resp, err := NewOCSPResponse(unknownCert, nil, tree)
+		if err != nil {
+			t.Fatalf("NewOCSPResponse() returned error: %v", err)
+		}
+		if resp.status != Unknown {
+			t.Errorf("Expected status Unknown (%d), got %d", Unknown, resp.status)
+		}
+	})
 }
+
 func TestGetStatus(t *testing.T) {
+	certs, err := GenerateRandBlocks(10)
+	if err != nil {
+		t.Fatalf("Failed to generate certs: %v", err)
+	}
+	tree, err := NewCombinedTree(certs)
+	if err != nil {
+		t.Fatalf("Failed to create combined tree: %v", err)
+	}
 
+	t.Run("Good - issued and not revoked", func(t *testing.T) {
+		status, err := getStatus(tree, certs[0])
+		if err != nil {
+			t.Fatalf("getStatus() returned error: %v", err)
+		}
+		if status != Good {
+			t.Errorf("Expected Good (%d), got %d", Good, status)
+		}
+	})
+
+	t.Run("Revoked - issued and revoked", func(t *testing.T) {
+		_, err := tree.addRevocationToTree(certs[1])
+		if err != nil {
+			t.Fatalf("Failed to revoke cert: %v", err)
+		}
+		status, err := getStatus(tree, certs[1])
+		if err != nil {
+			t.Fatalf("getStatus() returned error: %v", err)
+		}
+		if status != Revoked {
+			t.Errorf("Expected Revoked (%d), got %d", Revoked, status)
+		}
+	})
+
+	t.Run("Unknown - never issued", func(t *testing.T) {
+		status, err := getStatus(tree, []byte("not-in-tree"))
+		if err != nil {
+			t.Fatalf("getStatus() returned error: %v", err)
+		}
+		if status != Unknown {
+			t.Errorf("Expected Unknown (%d), got %d", Unknown, status)
+		}
+	})
+
+	t.Run("status changes after revocation", func(t *testing.T) {
+		statusBefore, err := getStatus(tree, certs[2])
+		if err != nil {
+			t.Fatalf("getStatus() before revocation returned error: %v", err)
+		}
+		if statusBefore != Good {
+			t.Errorf("Expected Good before revocation, got %d", statusBefore)
+		}
+
+		_, err = tree.addRevocationToTree(certs[2])
+		if err != nil {
+			t.Fatalf("Failed to revoke cert: %v", err)
+		}
+
+		statusAfter, err := getStatus(tree, certs[2])
+		if err != nil {
+			t.Fatalf("getStatus() after revocation returned error: %v", err)
+		}
+		if statusAfter != Revoked {
+			t.Errorf("Expected Revoked after revocation, got %d", statusAfter)
+		}
+	})
+
+	t.Run("revoked-but-unknown - revoked but never issued", func(t *testing.T) {
+		ghostCert := []byte("revoked-but-never-issued")
+		_, err := tree.addRevocationToTree(ghostCert)
+		if err != nil {
+			t.Fatalf("Failed to add ghost revocation: %v", err)
+		}
+		// isIssued check comes first in getStatus, so this should return Unknown
+		status, err := getStatus(tree, ghostCert)
+		if err != nil {
+			t.Fatalf("getStatus() returned error: %v", err)
+		}
+		if status != Unknown {
+			t.Errorf("Expected Unknown for revoked-but-never-issued cert, got %d", status)
+		}
+	})
 }


### PR DESCRIPTION
Refactor and tighten unit tests, fix merkle block generation, and handle OCSP response errors.

- Tests: reorganized and simplified multiple test files (combinedtree_test.go, ocsp_merkle_test.go). Removed/merged several older tests, added clearer subtests and assertions, consolidated membership/non-membership checks into TestValidateSparseMTProofs, and improved error messages and table-driven checks for OCSP status/getStatus behavior (Good/Revoked/Unknown).
- merkle.go: moved NewKeyPair call inside the GenerateRandBlocks loop so each generated certificate is created with its own key and errors are handled per iteration.
- main.go: check and handle error returned from NewOCSPResponse and print a clearer response status message.

These changes improve test coverage clarity, fix block generation bug, and make OCSP runtime behavior and logging more robust.